### PR TITLE
Only set paths in initializer if they haven't been set

### DIFF
--- a/lib/swagger_yard/rails/engine.rb
+++ b/lib/swagger_yard/rails/engine.rb
@@ -8,8 +8,8 @@ module SwaggerYard
 
       initializer "swagger_yard-rails.paths" do |app|
         SwaggerYard.configure do |config|
-          config.controller_path = ::Rails.root + 'app/controllers/**/*'
-          config.model_path      = ::Rails.root + 'app/models/**/*'
+          config.controller_path ||= ::Rails.root + 'app/controllers/**/*'
+          config.model_path      ||= ::Rails.root + 'app/models/**/*'
         end
       end
 


### PR DESCRIPTION
The initializer actually runs _after_ `config/initializers`, so if paths were set there, they get overwritten.
