### PR TITLE
Openapi and v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.2
-before_install: gem install bundler -v 1.10.6
+  - 2.2.7
+
+env:
+  - RAILS_VERSION='~>4.2' # 4.2 series
+  - RAILS_VERSION='~>5.0.0' # 5.0 series
+  - RAILS_VERSION='>=5.0.0' # latest 5.x series

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add OpenAPI stuff -- `/swagger/openapi.json` route and `openapi:json` task
 * Bump dependency on swagger_yard to >= 1.0.0
+* Test on Rails 4.2, Rails 5.0, and latest Rails release
 
 ## 0.3.3 25-07-2016 ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SwaggerYard-Rails Changelog
 
+## 1.0.0 28-06-2018 ##
+
+* Add OpenAPI stuff -- `/swagger/openapi.json` route and `openapi:json` task
+* Bump dependency on swagger_yard to >= 1.0.0
+
 ## 0.3.3 25-07-2016 ##
 
 * Descend into engine routes when searching for matches. This allows documented

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,13 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in swagger_yard-rails.gemspec
 gemspec
+
+if ENV['RAILS_VERSION']
+  gem 'rails', ENV['RAILS_VERSION']
+elsif File.exist?('Gemfile.lock')
+  # use whatever version is currently installed
+  version = File.read('Gemfile.lock').scan(/DEPENDENCIES.*/m).first[/rails \((.*?)\)/m, 1]
+  gem 'rails', version
+else
+  gem 'rails', '~> 4.2'
+end

--- a/app/controllers/swagger_yard/rails/swagger_controller.rb
+++ b/app/controllers/swagger_yard/rails/swagger_controller.rb
@@ -9,6 +9,10 @@ module SwaggerYard
       def index
         render :json => Swagger.new.to_h
       end
+
+      def openapi
+        render :json => OpenAPI.new.to_h
+      end
     end
   end
 end

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "swagger_yard/rails"
+require File.expand_path('../../spec/spec_helper', __FILE__)
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ SwaggerYard::Rails::Engine.routes.draw do
 
   scope default: {format: 'json'} do
     get '/swagger', to: 'swagger#index'
+    get '/openapi', to: 'swagger#openapi'
     get '/api', to: 'swagger#index'
   end
 end

--- a/lib/swagger_yard/rails/route_inspector.rb
+++ b/lib/swagger_yard/rails/route_inspector.rb
@@ -19,7 +19,8 @@ module SwaggerYard
           info      = yard_info(yard_obj)
           route_arr = find_route(info)
           route     = route_arr.last
-          method    = route.verb.source.gsub(/[$^]/, '')
+          method    = route.verb
+          method    = method.source.gsub(/[$^]/, '') if method.respond_to?(:source)
 
           raise Error, "no http method: #{info.inspect}" if method.empty?
 

--- a/lib/swagger_yard/rails/tasks.rake
+++ b/lib/swagger_yard/rails/tasks.rake
@@ -5,3 +5,11 @@ namespace :swagger do
     end
   end
 end
+
+namespace :openapi do
+  task :json, [:filename] => :environment do |t, args|
+    File.open(args[:filename] || "openapi.json", "w") do |f|
+      f.puts JSON.pretty_generate(SwaggerYard::OpenAPI.new.to_h)
+    end
+  end
+end

--- a/lib/swagger_yard/rails/version.rb
+++ b/lib/swagger_yard/rails/version.rb
@@ -1,5 +1,5 @@
 module SwaggerYard
   module Rails
-    VERSION = "0.3.3"
+    VERSION = "1.0.0"
   end
 end

--- a/spec/fixtures/dummy/app/controllers/application_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
-# 
+#
 # @authorization [api_key] header X-APPLICATION-API-KEY
-# 
+#
 class ApplicationController < ActionController::Base
 end

--- a/spec/fixtures/dummy/app/controllers/pets_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/pets_controller.rb
@@ -1,10 +1,9 @@
 # @resource Pet
-# @resource_path /pets
-# 
+#
 # This document describes the API for interacting with Pet resources
-# 
+#
 # @authorize_with header_x_application_api_key
-# 
+#
 class PetsController < ApplicationController
   # return a list of Pets
   # @response_type [Array<Pet>]

--- a/spec/fixtures/dummy/config/application.rb
+++ b/spec/fixtures/dummy/config/application.rb
@@ -12,7 +12,7 @@ module Dummy
       config.assets.enabled = false
     end
 
-    if Rails::VERSION::MAJOR >= 5
+    if config.respond_to?(:load_defaults)
       config.load_defaults "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}".to_f
     end
   end

--- a/spec/fixtures/dummy/config/application.rb
+++ b/spec/fixtures/dummy/config/application.rb
@@ -7,8 +7,14 @@ module Dummy
   class Application < Rails::Application
     config.root = File.expand_path('../../', __FILE__)
 
-    # Disable the asset pipeline.
-    config.assets.enabled = false
+    if Rails::VERSION::MAJOR < 5
+      # Disable the asset pipeline.
+      config.assets.enabled = false
+    end
+
+    if Rails::VERSION::MAJOR >= 5
+      config.load_defaults "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}".to_f
+    end
   end
 end
 

--- a/spec/fixtures/dummy/config/initializers/swagger_yard.rb
+++ b/spec/fixtures/dummy/config/initializers/swagger_yard.rb
@@ -1,7 +1,6 @@
 SwaggerYard.configure do |config|
   config.title = "Dummy App"
   config.description = "Dummy application for testing SwaggerYard and Rails"
-  config.reload = true
   config.api_version = "1.0"
   config.api_base_path = "http://localhost:3000/api"
 end

--- a/spec/swagger_yard/integration/openapi_json_spec.rb
+++ b/spec/swagger_yard/integration/openapi_json_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe "openapi.json", :type => :request do
+  before { get "/swagger/openapi.json" }
+
+  context "returns an OK response" do
+    subject { response }
+    its(:code) { is_expected.to eq("200") }
+  end
+
+  context "openapi model" do
+    subject(:openapi) { JSON.parse(response.body) }
+
+    its(['paths']) { are_expected.to include('/pets', '/transports', '/pets/{id}')}
+
+    context "/pets" do
+      subject { openapi['paths']['/pets'] }
+
+      it { is_expected.to include('get', 'post') }
+
+      its(['get']) { is_expected.to include('summary' => 'return a list of Pets')}
+
+      its(['post']) { is_expected.to include('summary' => 'create a Pet')}
+
+      context "update action is not documented" do
+        it { is_expected.to_not include('put') }
+      end
+    end
+  end
+end

--- a/spec/swagger_yard/rails/route_inspector_spec.rb
+++ b/spec/swagger_yard/rails/route_inspector_spec.rb
@@ -90,4 +90,25 @@ RSpec.describe SwaggerYard::Rails::RouteInspector do
       subject.call(missing_obj)
     end.to raise_error(described_class::Error)
   end
+
+  context "with Rails 5ish routes" do
+    let(:routes) {
+      [stub(defaults: { controller: 'foo', action: 'index'},
+            app: nil,
+            name: nil,
+            ast: '/foo(.:format)',
+            verb: 'GET',
+            parts: [:format]),
+       stub(defaults: { controller: 'pets', action: 'index' },
+            app: nil,
+            name: nil,
+            ast: '/pets(.:format)',
+            verb: 'GET',
+            parts: [:format])]
+     }
+
+    it 'looks up the route in the router' do
+      expect(subject.call(pets_index_obj)).to eq(["GET", "/pets"])
+    end
+  end
 end

--- a/swagger_yard-rails.gemspec
+++ b/swagger_yard-rails.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", ">= 3.2.8"
-  spec.add_dependency "swagger_yard", "~> 0.2"
+  spec.add_dependency "swagger_yard", ">= 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
* Add OpenAPI stuff -- `/swagger/openapi.json` route and `openapi:json` task
* Bump dependency on swagger_yard to >= 1.0.0
* Test on Rails 4.2, Rails 5.0, and latest Rails release